### PR TITLE
Add an example helper for rspec

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -1,0 +1,2 @@
+# This file is loaded by discourse when plugin specs are run.
+# Include any helper, fixtures, etc for your plugin here.


### PR DESCRIPTION
So developers can see an example how to include spec helpers for their plugins. 

This depends on: https://github.com/discourse/discourse/pull/4877

